### PR TITLE
Notify app of error state upon end without data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ clamavstreamscan = function(port, host, stream, complete, object, callback) {
   socket.connect(port, host, function() {
     var channel = new ClamAVChannel();
     stream.pipe(channel).pipe(socket).on('end', function() {
+      if (status === '') {
+        callback(new Error('No response received from ClamAV. Consider increasing MaxThreads in clamd.conf'), object);
+      }
       complete(stream);
     }).on('error', function(err) {
       callback(new Error(err), object);


### PR DESCRIPTION
(partial) fix for #6 and #7. I have only seen the `end` event occur when there is no `data` event received back from ClamAV, the `if (status === '')` is redundant.  In #6 @corybill suggests that the error state be handled in the `close` event at line 72, in which case the status check would definitely be required.

I suspect that the issues of #6 and #7 can be avoided by increasing the `MaxThreads` and/or throttling the number of connections which are attempted at the same time.  Ideally, the clamd service should be made more robust.

See also: https://bugzilla.clamav.net/show_bug.cgi?id=12181